### PR TITLE
Add missing semicolon and fix a typo with a comma.

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -14,7 +14,7 @@ angular.module('starter.controllers', [])
   // Triggered in the login modal to close it
   $scope.closeLogin = function() {
     $scope.modal.hide();
-  },
+  };
 
   // Open the login modal
   $scope.login = function() {
@@ -45,4 +45,4 @@ angular.module('starter.controllers', [])
 })
 
 .controller('PlaylistCtrl', function($scope, $stateParams) {
-})
+});


### PR DESCRIPTION
There was a comma instead of a semicolon and also a missing semicolon at the bottom.
