### PR TITLE
Sanitize the ms-appx prefix WP8 adds to dynamic URL

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,7 +20,9 @@ angular.module('starter', ['ionic', 'starter.controllers'])
   });
 })
 
-.config(function($stateProvider, $urlRouterProvider) {
+.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
+  $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|file|ghttps?|ms-appx|x-wmapp0):/) //WP8
+
   $stateProvider
 
   .state('app', {


### PR DESCRIPTION
See http://appfoundry.be/blog/2014/10/16/ionic-windows-phone/#ms-appx-ie-problem for an extended explanation.
