### PR TITLE
Fix inconsistent indentation in app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -25,7 +25,7 @@ angular.module('starter', ['ionic', 'starter.controllers'])
 .config(function($stateProvider, $urlRouterProvider) {
   $stateProvider
 
-    .state('app', {
+  .state('app', {
     url: '/app',
     abstract: true,
     templateUrl: 'templates/menu.html',


### PR DESCRIPTION
The `.state` line was improperly indented on a single line. I changed the first line of this code block...

``` javascript
    .state('app', {
    url: '/app',
    abstract: true,
    templateUrl: 'templates/menu.html',
    controller: 'AppCtrl'
  })
```

to...

``` javascript
  .state('app', {
    url: '/app',
    abstract: true,
    templateUrl: 'templates/menu.html',
    controller: 'AppCtrl'
  })
```