### PR TITLE
Add intermediate check for plugins when device is ready

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@ angular.module('starter', ['ionic', 'starter.controllers'])
   $ionicPlatform.ready(function() {
     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
     // for form inputs)
-    if (window.cordova && window.cordova.plugins.Keyboard) {
+    if (window.cordova && window.cordova.plugins && window.cordova.plugins.Keyboard) {
       cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);
       cordova.plugins.Keyboard.disableScroll(true);
 


### PR DESCRIPTION
Usually I would add all my bootstrapping logic right after this check. If the plugins object did not exist then it would throw an exception("Uncaught Type Error") and the rest of the function would not execute. This is a corner case because it would only show up on devices but unless someone is debugging with safari or chrome tools it could be totally missed.
